### PR TITLE
Tidy ugly dependency on `CatalogBomScanner` in the tracker and loader.

### DIFF
--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogBundleTracker.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogBundleTracker.java
@@ -20,10 +20,9 @@
 package org.apache.brooklyn.core.catalog.internal;
 
 import org.apache.brooklyn.api.catalog.CatalogItem;
-import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleEvent;
-import org.osgi.framework.ServiceReference;
 import org.osgi.util.tracker.BundleTracker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,36 +34,11 @@ public class CatalogBundleTracker extends BundleTracker<Iterable<? extends Catal
 
     private static final Logger LOG = LoggerFactory.getLogger(CatalogBundleTracker.class);
 
-    private ServiceReference<ManagementContext> mgmtContextReference;
-    private ManagementContext managementContext;
-
-    private CatalogBomScanner catalogBomScanner;
     private CatalogBundleLoader catalogBundleLoader;
 
-    public CatalogBundleTracker(CatalogBomScanner catalogBomScanner, ServiceReference<ManagementContext> serviceReference) {
-        super(serviceReference.getBundle().getBundleContext(), Bundle.ACTIVE, null);
-        this.mgmtContextReference = serviceReference;
-        this.catalogBomScanner = catalogBomScanner;
-        open();
-    }
-
-    @Override
-    public void open() {
-        managementContext = mgmtContextReference.getBundle().getBundleContext().getService(mgmtContextReference);
-        catalogBundleLoader = new CatalogBundleLoader(catalogBomScanner, managementContext);
-        super.open();
-    }
-
-    @Override
-    public void close() {
-        super.close();
-        managementContext = null;
-        mgmtContextReference.getBundle().getBundleContext().ungetService(mgmtContextReference);
-        catalogBundleLoader = null;
-    }
-
-    public ManagementContext getManagementContext() {
-        return managementContext;
+    public CatalogBundleTracker(BundleContext bundleContext, CatalogBundleLoader catalogBundleLoader) {
+        super(bundleContext, Bundle.ACTIVE, null);
+        this.catalogBundleLoader = catalogBundleLoader;
     }
 
     /**
@@ -94,7 +68,7 @@ public class CatalogBundleTracker extends BundleTracker<Iterable<? extends Catal
         if (!items.iterator().hasNext()) {
             return;
         }
-        LOG.debug("Unloading catalog BOM entries from {} {} {}", catalogBomScanner.bundleIds(bundle));
+        LOG.debug("Unloading catalog BOM entries from {} {} {}", CatalogUtils.bundleIds(bundle));
         for (CatalogItem<?, ?> item : items) {
             LOG.debug("Unloading {} {} from catalog", item.getSymbolicName(), item.getVersion());
 

--- a/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogUtils.java
+++ b/core/src/main/java/org/apache/brooklyn/core/catalog/internal/CatalogUtils.java
@@ -48,6 +48,7 @@ import org.apache.brooklyn.core.typereg.RegisteredTypes;
 import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.text.Strings;
 import org.apache.brooklyn.util.time.Time;
+import org.osgi.framework.Bundle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -323,4 +324,10 @@ public class CatalogUtils {
         mgmt.getCatalog().persist(item);
     }
 
+
+    public static String[] bundleIds(Bundle bundle) {
+        return new String[] {
+            String.valueOf(bundle.getBundleId()), bundle.getSymbolicName(), bundle.getVersion().toString()
+        };
+    }
 }

--- a/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/CatalogResource.java
+++ b/rest/rest-resources/src/main/java/org/apache/brooklyn/rest/resources/CatalogResource.java
@@ -247,7 +247,10 @@ public class CatalogResource extends AbstractBrooklynRestResource implements Cat
             if (!BrooklynFeatureEnablement.isEnabled(BrooklynFeatureEnablement.FEATURE_LOAD_BUNDLE_CATALOG_BOM)) {
                 // if the above feature is not enabled, let's do it manually (as a contract of this method)
                 try {
-                    new CatalogBundleLoader(new CatalogBomScanner(), mgmt()).scanForCatalog(bundle);
+                    // TODO improve on this - it ignores the configuration of whitelists, see CatalogBomScanner.
+                    final Predicate<Bundle> applicationsPermitted = Predicates.<Bundle>alwaysTrue();
+
+                    new CatalogBundleLoader(applicationsPermitted, mgmt()).scanForCatalog(bundle);
                 } catch (RuntimeException ex) {
                     try {
                         bundle.uninstall();


### PR DESCRIPTION
Replace it with a simple predicate that wraps the whitelist checks and
inject the predicate into the loader. That way the CatalogBomScanner
can inject the correct whitelist configuration in the blueprint.xml,
while in the REST API here we just live with an "always true" for the
moment.

Create the loader the scanner and inject it into the tracker,
which simplifies the latter a bit.

CAVEAT: this is for review for you to see what you think, I have not
tested this!